### PR TITLE
h265nal: use comma separated output format

### DIFF
--- a/src/h265_nal_unit_parser.cc
+++ b/src/h265_nal_unit_parser.cc
@@ -291,7 +291,7 @@ void H265NalUnitParser::NalUnitState::fdump(FILE* outfp, int indent_level,
   // nal unit parsed length (starting at NAL unit header)
   if (add_parsed_length) {
     fdump_indent_level(outfp, indent_level);
-    fprintf(outfp, "parsed_length: 0x%08zx", parsed_length);
+    fprintf(outfp, "parsed_length: %zu", parsed_length);
   }
 
   // nal unit checksum

--- a/tools/h265nal.cc
+++ b/tools/h265nal.cc
@@ -293,7 +293,7 @@ int main(int argc, char **argv) {
     if (options->add_contents) {
       fprintf(outfp, " contents {");
       for (size_t i = 0; i < nal_unit->length; i++) {
-        fprintf(outfp, " %02x", buffer[nal_unit->offset + i]);
+        fprintf(outfp, " 0x%02x,", buffer[nal_unit->offset + i]);
         if ((i + 1) % 16 == 0) {
           fprintf(outfp, " ");
         }


### PR DESCRIPTION
* Use comma separated output format for printing nalu payload ("contents")
* Change the parsed length format to decimal from hex for more readability