### PR TITLE
h265nal: fix array sizes in short-term reference parser

### DIFF
--- a/src/h265_st_ref_pic_set_parser.cc
+++ b/src/h265_st_ref_pic_set_parser.cc
@@ -38,7 +38,7 @@ void H265StRefPicSetParser::StRefPicSetState::DeriveValues(
     const std::vector<std::unique_ptr<struct StRefPicSetState>>*
         st_ref_pic_set_state_vector,
     const uint32_t RefRpsIdx) noexcept {
-#define HEVC_MAX_REFS 16
+#define HEVC_MAX_REFS h265limits::NUM_SHORT_TERM_REF_PIC_SETS_MAX
   int ref_delta_poc_s0[HEVC_MAX_REFS] = {0};
   int ref_delta_poc_s1[HEVC_MAX_REFS] = {0};
   int delta_poc_s0[HEVC_MAX_REFS] = {0};


### PR DESCRIPTION
Fixes a crash that happened due to out-of-bounds array access while processing h265 frames. The overflow happened because the local arrays in H265StRefPicSetParser::StRefPicSetState::DeriveValues() method were incorrectly sized, so the diff fixes sizes of the arrays.