### PR TITLE
h265nal: fix out of bounds array access in h265 st ref parsing

### DIFF
--- a/src/h265_common.h
+++ b/src/h265_common.h
@@ -88,6 +88,11 @@ namespace h265limits {
 // 0 to 64, inclusive."
 const uint32_t NUM_SHORT_TERM_REF_PIC_SETS_MAX = 64;
 
+// Rec. ITU-T H.265 F.7.4.8
+// The value of num_positive_pics / num_negative_pics shall be in the range of
+// 0 to MaxDpbSize-1, inclusive.
+const uint32_t HEVC_MAX_DPB_SIZE = 16;
+
 // Rec. ITU-T H.265 v5 (02/2018) Page 74
 // "vps_max_layer_id shall be less than 63 in bitstreams conforming
 // to this version of this Specification."

--- a/src/h265_sps_parser.cc
+++ b/src/h265_sps_parser.cc
@@ -167,6 +167,10 @@ std::shared_ptr<H265SpsParser::SpsState> H265SpsParser::ParseSps(
     if (!bit_buffer->ReadExponentialGolomb(&golomb_tmp)) {
       return nullptr;
     }
+    // sps_max_dec_pic_buffering_minus1 shall be in range 0 to MaxDpbSize-1, inclusive
+    if(golomb_tmp >= h265limits::HEVC_MAX_DPB_SIZE) {
+      return nullptr;
+    }
     sps->sps_max_dec_pic_buffering_minus1.push_back(golomb_tmp);
     // sps_max_num_reorder_pics[i]  ue(v)
     if (!bit_buffer->ReadExponentialGolomb(&golomb_tmp)) {

--- a/src/h265_st_ref_pic_set_parser.cc
+++ b/src/h265_st_ref_pic_set_parser.cc
@@ -197,6 +197,11 @@ H265StRefPicSetParser::ParseStRefPicSet(
     uint32_t NumDeltaPocs_RefRpsIdx =
         ref->num_negative_pics + ref->num_positive_pics;
 
+    // F.7.4.8: DeltaPoCs shall be in range 0 to MaxDpbSize-1, inclusive
+    if(NumDeltaPocs_RefRpsIdx >= h265limits::HEVC_MAX_DPB_SIZE) {
+      return nullptr;
+    }
+
     for (uint32_t j = 0; j <= NumDeltaPocs_RefRpsIdx; j++) {
       // used_by_curr_pic_flag[j]  u(1)
       if (!bit_buffer->ReadBits(&bits_tmp, 1)) {


### PR DESCRIPTION
References to FFMpeg where similar logic is implemented: 

https://github.com/FFmpeg/FFmpeg/blob/master/libavcodec/cbs_h265_syntax_template.c#L544

https://github.com/FFmpeg/FFmpeg/blob/master/libavcodec/cbs_h265_syntax_template.c#L849