### PR TITLE
h265nal: support for serialization of sei messages and payload states

### DIFF
--- a/include/h265_sei_parser.h
+++ b/include/h265_sei_parser.h
@@ -104,6 +104,8 @@ class H265SeiPayloadParser {
     H265SeiPayloadState(H265SeiPayloadState&&) = delete;
     H265SeiPayloadState& operator=(const H265SeiPayloadState&) = delete;
     H265SeiPayloadState& operator=(H265SeiPayloadState&&) = delete;
+    virtual void serialize(std::vector<uint8_t>& bytes) const = 0;
+
 #ifdef FDUMP_DEFINE
     virtual void fdump(FILE* outfp, int indent_level) const = 0;
 #endif  // FDUMP_DEFINE
@@ -127,6 +129,7 @@ class H265SeiUserDataRegisteredItuTT35Parser : public H265SeiPayloadParser {
         const H265SeiUserDataRegisteredItuTT35State&) = delete;
     H265SeiUserDataRegisteredItuTT35State& operator=(
         H265SeiUserDataRegisteredItuTT35State&&) = delete;
+    virtual void serialize(std::vector<uint8_t>& bytes) const;
 
 #ifdef FDUMP_DEFINE
     virtual void fdump(FILE* outfp, int indent_level) const;
@@ -150,6 +153,7 @@ class H265SeiUnknownParser : public H265SeiPayloadParser {
     H265SeiUnknownState(H265SeiUnknownState&&) = delete;
     H265SeiUnknownState& operator=(const H265SeiUnknownState&) = delete;
     H265SeiUnknownState& operator=(H265SeiUnknownState&&) = delete;
+    virtual void serialize(std::vector<uint8_t>& bytes) const;
 
 #ifdef FDUMP_DEFINE
     virtual void fdump(FILE* outfp, int indent_level) const;
@@ -171,6 +175,7 @@ class H265SeiMessageParser {
     SeiMessageState(SeiMessageState&&) = delete;
     SeiMessageState& operator=(const SeiMessageState&) = delete;
     SeiMessageState& operator=(SeiMessageState&&) = delete;
+    void serialize(std::vector<uint8_t>& bytes) const;
 
 #ifdef FDUMP_DEFINE
     virtual void fdump(FILE* outfp, int indent_level) const;

--- a/include/h265_sei_parser.h
+++ b/include/h265_sei_parser.h
@@ -148,10 +148,8 @@ class H265SeiUnknownParser : public H265SeiPayloadParser {
     // disable copy ctor, move ctor, and copy&move assignments
     H265SeiUnknownState(const H265SeiUnknownState&) = delete;
     H265SeiUnknownState(H265SeiUnknownState&&) = delete;
-    H265SeiUnknownState& operator=(const H265SeiUnknownState&) =
-        delete;
-    H265SeiUnknownState& operator=(H265SeiUnknownState&&) =
-        delete;
+    H265SeiUnknownState& operator=(const H265SeiUnknownState&) = delete;
+    H265SeiUnknownState& operator=(H265SeiUnknownState&&) = delete;
 
 #ifdef FDUMP_DEFINE
     virtual void fdump(FILE* outfp, int indent_level) const;

--- a/src/h265_sei_parser.cc
+++ b/src/h265_sei_parser.cc
@@ -150,6 +150,7 @@ void H265SeiMessageParser::SeiMessageState::fdump(FILE* outfp,
   fdump_indent_level(outfp, indent_level);
   fprintf(outfp, "payload_size: %u", payload_size);
 
+  fdump_indent_level(outfp, indent_level);
   payload_state->fdump(outfp, indent_level);
 
   indent_level = indent_level_decr(indent_level);

--- a/src/h265_sei_parser.cc
+++ b/src/h265_sei_parser.cc
@@ -102,7 +102,8 @@ H265SeiUserDataRegisteredItuTT35Parser::parse_payload(
     }
 
     // itu_t_t35_country_code_extension_byte  b(8)
-    if (!bit_buffer->ReadUInt8(payload_state->itu_t_t35_country_code_extension_byte)) {
+    if (!bit_buffer->ReadUInt8(
+            payload_state->itu_t_t35_country_code_extension_byte)) {
       return nullptr;
     }
     remaining_payload_size--;
@@ -120,7 +121,7 @@ H265SeiUserDataRegisteredItuTT35Parser::parse_payload(
 
 std::unique_ptr<H265SeiPayloadParser::H265SeiPayloadState>
 H265SeiUnknownParser::parse_payload(rtc::BitBuffer* bit_buffer,
-                                           uint32_t payload_size) {
+                                    uint32_t payload_size) {
   // We have no specific details for this sei, just keep all the bytes
   // in a payload buffer.
   uint32_t remaining_payload_size = payload_size;
@@ -186,8 +187,8 @@ void H265SeiUserDataRegisteredItuTT35Parser::
   fprintf(outfp, "}");
 }
 
-void H265SeiUnknownParser::H265SeiUnknownState::fdump(
-    FILE* outfp, int indent_level) const {
+void H265SeiUnknownParser::H265SeiUnknownState::fdump(FILE* outfp,
+                                                      int indent_level) const {
   fprintf(outfp, "unimplemented {");
   indent_level = indent_level_incr(indent_level);
 

--- a/src/h265_sei_parser.cc
+++ b/src/h265_sei_parser.cc
@@ -77,6 +77,27 @@ H265SeiMessageParser::ParseSei(rtc::BitBuffer* bit_buffer) noexcept {
   return sei_message_state;
 }
 
+void H265SeiMessageParser::SeiMessageState::serialize(
+    std::vector<uint8_t>& bytes) const {
+  uint32_t remaining_type = static_cast<uint8_t>(payload_type);
+  while (remaining_type > 0xff) {
+    bytes.push_back(0xff);
+    remaining_type -= 0xff;
+  }
+  bytes.push_back(static_cast<uint8_t>(remaining_type));
+
+  uint32_t remaining_size = payload_size;
+  while (remaining_size > 0xff) {
+    bytes.push_back(0xff);
+    remaining_size -= 0xff;
+  }
+  bytes.push_back(static_cast<uint8_t>(remaining_size));
+
+  if (payload_state) {
+    payload_state->serialize(bytes);
+  }
+}
+
 std::unique_ptr<H265SeiPayloadParser::H265SeiPayloadState>
 H265SeiUserDataRegisteredItuTT35Parser::parse_payload(
     rtc::BitBuffer* bit_buffer, uint32_t payload_size) {
@@ -119,6 +140,18 @@ H265SeiUserDataRegisteredItuTT35Parser::parse_payload(
   return payload_state;
 }
 
+void H265SeiUserDataRegisteredItuTT35Parser::
+    H265SeiUserDataRegisteredItuTT35State::serialize(
+        std::vector<uint8_t>& bytes) const {
+  if (itu_t_t35_country_code == 0xff) {
+    bytes.push_back(itu_t_t35_country_code);
+    bytes.push_back(itu_t_t35_country_code_extension_byte);
+  } else {
+    bytes.push_back(itu_t_t35_country_code);
+  }
+  bytes.insert(bytes.end(), payload.begin(), payload.end());
+}
+
 std::unique_ptr<H265SeiPayloadParser::H265SeiPayloadState>
 H265SeiUnknownParser::parse_payload(rtc::BitBuffer* bit_buffer,
                                     uint32_t payload_size) {
@@ -136,6 +169,11 @@ H265SeiUnknownParser::parse_payload(rtc::BitBuffer* bit_buffer,
     }
   }
   return payload_state;
+}
+
+void H265SeiUnknownParser::H265SeiUnknownState::serialize(
+    std::vector<uint8_t>& bytes) const {
+  bytes.insert(bytes.end(), payload.begin(), payload.end());
 }
 
 #ifdef FDUMP_DEFINE

--- a/test/h265_sei_parser_unittest.cc
+++ b/test/h265_sei_parser_unittest.cc
@@ -43,6 +43,9 @@ TEST_F(H265SeiParserTest, TestUserDataRegisteredItuTT35Sei) {
   EXPECT_TRUE(user_data_sei != nullptr);
   EXPECT_EQ(user_data_sei->itu_t_t35_country_code, 181);
   EXPECT_EQ(user_data_sei->itu_t_t35_country_code_extension_byte, 0);
+  std::vector<uint8_t> serialized_bytes;
+  sei_message->serialize(serialized_bytes);
+  EXPECT_EQ(memcmp(buffer, serialized_bytes.data(), serialized_bytes.size()), 0);
 }
 
 TEST_F(H265SeiParserTest, TestUnknownSei) {
@@ -63,6 +66,9 @@ TEST_F(H265SeiParserTest, TestUnknownSei) {
   auto unimplemented_state = dynamic_cast<H265SeiUnknownParser::H265SeiUnknownState*>(sei_message->payload_state.get());
   EXPECT_TRUE(unimplemented_state != nullptr);
   EXPECT_EQ(unimplemented_state->payload.size(), 256);
+  std::vector<uint8_t> serialized_bytes;
+  sei_message->serialize(serialized_bytes);
+  EXPECT_EQ(memcmp(buffer.data(), serialized_bytes.data(), serialized_bytes.size()), 0);
 }
 
 }  // namespace h265nal


### PR DESCRIPTION
A few small changes:

- h265nal: add unit test for H265SeiUnknownParser
- h265nal: adjust indent level for the state payload
- h265nal: apply clang google style formatting fixes
- h265nal: support for serialization of sei messages and payload states
- h265nal: add serialization to sei state unit tests