### PR TITLE
h265nal: replace int types include

### DIFF
--- a/src/h265_configuration_box_parser.cc
+++ b/src/h265_configuration_box_parser.cc
@@ -4,8 +4,8 @@
 
 #include "h265_configuration_box_parser.h"
 
-#define __STDC_FORMAT_MACROS
-#include <inttypes.h>
+
+#include <cinttypes>
 #include <stdio.h>
 
 #include <cstdint>

--- a/src/h265_pps_multilayer_extension_parser.cc
+++ b/src/h265_pps_multilayer_extension_parser.cc
@@ -4,8 +4,8 @@
 
 #include "h265_pps_multilayer_extension_parser.h"
 
-#define __STDC_FORMAT_MACROS
-#include <inttypes.h>
+
+#include <cinttypes>
 #include <stdio.h>
 
 #include <cstdint>

--- a/src/h265_pps_scc_extension_parser.cc
+++ b/src/h265_pps_scc_extension_parser.cc
@@ -4,8 +4,8 @@
 
 #include "h265_pps_scc_extension_parser.h"
 
-#define __STDC_FORMAT_MACROS
-#include <inttypes.h>
+
+#include <cinttypes>
 #include <stdio.h>
 
 #include <cstdint>

--- a/src/h265_pred_weight_table_parser.cc
+++ b/src/h265_pred_weight_table_parser.cc
@@ -4,8 +4,8 @@
 
 #include "h265_pred_weight_table_parser.h"
 
-#define __STDC_FORMAT_MACROS
-#include <inttypes.h>
+
+#include <cinttypes>
 #include <stdio.h>
 
 #include <cstdint>

--- a/src/h265_profile_tier_level_parser.cc
+++ b/src/h265_profile_tier_level_parser.cc
@@ -4,8 +4,8 @@
 
 #include "h265_profile_tier_level_parser.h"
 
-#define __STDC_FORMAT_MACROS
-#include <inttypes.h>
+
+#include <cinttypes>
 #include <stdio.h>
 
 #include <cstdint>

--- a/src/h265_scaling_list_data_parser.cc
+++ b/src/h265_scaling_list_data_parser.cc
@@ -4,8 +4,8 @@
 
 #include "h265_scaling_list_data_parser.h"
 
-#define __STDC_FORMAT_MACROS
-#include <inttypes.h>
+
+#include <cinttypes>
 #include <stdio.h>
 
 #include <algorithm>

--- a/src/h265_sei_parser.cc
+++ b/src/h265_sei_parser.cc
@@ -4,7 +4,7 @@
 
 #include "h265_sei_parser.h"
 
-#include <inttypes.h>
+#include <cinttypes>
 #include <stdio.h>
 
 #include <cstdint>

--- a/src/h265_slice_parser.cc
+++ b/src/h265_slice_parser.cc
@@ -4,8 +4,8 @@
 
 #include "h265_slice_parser.h"
 
-#define __STDC_FORMAT_MACROS
-#include <inttypes.h>
+
+#include <cinttypes>
 #include <stdio.h>
 
 #include <cmath>

--- a/src/h265_sps_3d_extension_parser.cc
+++ b/src/h265_sps_3d_extension_parser.cc
@@ -4,8 +4,8 @@
 
 #include "h265_sps_3d_extension_parser.h"
 
-#define __STDC_FORMAT_MACROS
-#include <inttypes.h>
+
+#include <cinttypes>
 #include <stdio.h>
 
 #include <cstdint>

--- a/src/h265_sps_multilayer_extension_parser.cc
+++ b/src/h265_sps_multilayer_extension_parser.cc
@@ -4,8 +4,8 @@
 
 #include "h265_sps_multilayer_extension_parser.h"
 
-#define __STDC_FORMAT_MACROS
-#include <inttypes.h>
+
+#include <cinttypes>
 #include <stdio.h>
 
 #include <cstdint>

--- a/src/h265_sps_parser.cc
+++ b/src/h265_sps_parser.cc
@@ -4,8 +4,8 @@
 
 #include "h265_sps_parser.h"
 
-#define __STDC_FORMAT_MACROS
-#include <inttypes.h>
+
+#include <cinttypes>
 #include <stdio.h>
 
 #include <cmath>

--- a/src/h265_sps_range_extension_parser.cc
+++ b/src/h265_sps_range_extension_parser.cc
@@ -4,8 +4,8 @@
 
 #include "h265_sps_range_extension_parser.h"
 
-#define __STDC_FORMAT_MACROS
-#include <inttypes.h>
+
+#include <cinttypes>
 #include <stdio.h>
 
 #include <cstdint>

--- a/src/h265_sps_scc_extension_parser.cc
+++ b/src/h265_sps_scc_extension_parser.cc
@@ -4,8 +4,8 @@
 
 #include "h265_sps_scc_extension_parser.h"
 
-#define __STDC_FORMAT_MACROS
-#include <inttypes.h>
+
+#include <cinttypes>
 #include <stdio.h>
 
 #include <cstdint>

--- a/src/h265_st_ref_pic_set_parser.cc
+++ b/src/h265_st_ref_pic_set_parser.cc
@@ -4,8 +4,8 @@
 
 #include "h265_st_ref_pic_set_parser.h"
 
-#define __STDC_FORMAT_MACROS
-#include <inttypes.h>
+
+#include <cinttypes>
 #include <stdio.h>
 
 #include <cstdint>

--- a/src/h265_vps_parser.cc
+++ b/src/h265_vps_parser.cc
@@ -4,8 +4,8 @@
 
 #include "h265_vps_parser.h"
 
-#define __STDC_FORMAT_MACROS
-#include <inttypes.h>
+
+#include <cinttypes>
 #include <stdio.h>
 
 #include <cstdint>

--- a/src/h265_vui_parameters_parser.cc
+++ b/src/h265_vui_parameters_parser.cc
@@ -4,8 +4,8 @@
 
 #include "h265_vui_parameters_parser.h"
 
-#define __STDC_FORMAT_MACROS
-#include <inttypes.h>
+
+#include <cinttypes>
 #include <stdio.h>
 
 #include <cstdint>


### PR DESCRIPTION
h265nal: replace int types include
Replace:
```
 #define __STDC_FORMAT_MACROS
 #include <inttypes.h>
```

with:
```
 #include <cinttypes>
```

per https://en.cppreference.com/w/cpp/types/integer.html

Tested:
```
$ make test
Running tests...
Test project /Users/zhoujian/Documents/Tools/fork/h265nal/build
      Start  1: h265_profile_tier_level_parser_unittest
 1/28 Test  #1: h265_profile_tier_level_parser_unittest .........   Passed    0.01 sec
      Start  2: h265_common_unittest
 2/28 Test  #2: h265_common_unittest ............................   Passed    0.01 sec
      Start  3: h265_utils_unittest
 3/28 Test  #3: h265_utils_unittest .............................   Passed    0.02 sec
      Start  4: h265_sub_layer_hrd_parameters_parser_unittest
 4/28 Test  #4: h265_sub_layer_hrd_parameters_parser_unittest ...   Passed    0.01 sec
      Start  5: h265_hrd_parameters_parser_unittest
 5/28 Test  #5: h265_hrd_parameters_parser_unittest .............   Passed    0.01 sec
      Start  6: h265_vps_parser_unittest
 6/28 Test  #6: h265_vps_parser_unittest ........................   Passed    0.01 sec
      Start  7: h265_vui_parameters_parser_unittest
 7/28 Test  #7: h265_vui_parameters_parser_unittest .............   Passed    0.01 sec
      Start  8: h265_pred_weight_table_parser_unittest
 8/28 Test  #8: h265_pred_weight_table_parser_unittest ..........   Passed    0.01 sec
      Start  9: h265_st_ref_pic_set_parser_unittest
 9/28 Test  #9: h265_st_ref_pic_set_parser_unittest .............   Passed    0.01 sec
      Start 10: h265_sps_multilayer_extension_parser_unittest
10/28 Test #10: h265_sps_multilayer_extension_parser_unittest ...   Passed    0.01 sec
      Start 11: h265_sps_3d_extension_parser_unittest
11/28 Test #11: h265_sps_3d_extension_parser_unittest ...........   Passed    0.01 sec
      Start 12: h265_sps_range_extension_parser_unittest
12/28 Test #12: h265_sps_range_extension_parser_unittest ........   Passed    0.01 sec
      Start 13: h265_sps_scc_extension_parser_unittest
13/28 Test #13: h265_sps_scc_extension_parser_unittest ..........   Passed    0.01 sec
      Start 14: h265_scaling_list_data_parser_unittest
14/28 Test #14: h265_scaling_list_data_parser_unittest ..........   Passed    0.01 sec
      Start 15: h265_sps_parser_unittest
15/28 Test #15: h265_sps_parser_unittest ........................   Passed    0.01 sec
      Start 16: h265_pps_multilayer_extension_parser_unittest
16/28 Test #16: h265_pps_multilayer_extension_parser_unittest ...   Passed    0.01 sec
      Start 17: h265_pps_scc_extension_parser_unittest
17/28 Test #17: h265_pps_scc_extension_parser_unittest ..........   Passed    0.01 sec
      Start 18: h265_pps_parser_unittest
18/28 Test #18: h265_pps_parser_unittest ........................   Passed    0.01 sec
      Start 19: h265_aud_parser_unittest
19/28 Test #19: h265_aud_parser_unittest ........................   Passed    0.01 sec
      Start 20: h265_sei_parser_unittest
20/28 Test #20: h265_sei_parser_unittest ........................   Passed    0.01 sec
      Start 21: h265_rtp_single_parser_unittest
21/28 Test #21: h265_rtp_single_parser_unittest .................   Passed    0.01 sec
      Start 22: h265_rtp_parser_unittest
22/28 Test #22: h265_rtp_parser_unittest ........................   Passed    0.01 sec
      Start 23: h265_rtp_ap_parser_unittest
23/28 Test #23: h265_rtp_ap_parser_unittest .....................   Passed    0.01 sec
      Start 24: h265_rtp_fu_parser_unittest
24/28 Test #24: h265_rtp_fu_parser_unittest .....................   Passed    0.01 sec
      Start 25: h265_slice_parser_unittest
25/28 Test #25: h265_slice_parser_unittest ......................   Passed    0.01 sec
      Start 26: h265_bitstream_parser_unittest
26/28 Test #26: h265_bitstream_parser_unittest ..................   Passed    0.01 sec
      Start 27: h265_nal_unit_parser_unittest
27/28 Test #27: h265_nal_unit_parser_unittest ...................   Passed    0.01 sec
      Start 28: h265_configuration_box_parser_unittest
28/28 Test #28: h265_configuration_box_parser_unittest ..........   Passed    0.01 sec

100% tests passed, 0 tests failed out of 28

Total Test time (real) =   0.33 sec
```

Operation:
```
$ cd h265nal
$ find src/ -name '*.cc' -print0 | xargs -0 perl -pi -e 's/inttypes\.h/cinttypes/g'
$ find src/ -name '*.cc' -print0 | xargs -0 perl -pi -e 's/#define __STDC_FORMAT_MACROS//g'
```